### PR TITLE
Disable access to the metadata service in AWS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+verify: bundle_install
+	bundle exec rake test
+
+bundle_install:
+	bundle install --path .bundle
+
+acceptance: bundle_install
+	bundle exec rake beaker:default

--- a/manifests/kubelet.pp
+++ b/manifests/kubelet.pp
@@ -42,6 +42,10 @@ class kubernetes::kubelet(
 
   $cluster_domain = $::kubernetes::cluster_domain
   $cluster_dns = $::kubernetes::_cluster_dns
+  $cloud_provider = $::kubernetes::cloud_provider
+
+  # TODO: this should come from something higher in the stack
+  $container_interface = 'cali+'
 
   $service_name = 'kubelet'
 
@@ -89,7 +93,7 @@ class kubernetes::kubelet(
   }
 
   $availability_zone = dig44($facts, ['ec2_metadata', 'placement', 'availability-zone'])
-  if $::kubernetes::cloud_provider == 'aws' and $availability_zone != undef {
+  if $cloud_provider == 'aws' and $availability_zone != undef {
     file{"${kubelet_dir}/plugins/kubernetes.io":
       ensure  => 'directory',
       mode    => '0750',

--- a/templates/kubelet.service.erb
+++ b/templates/kubelet.service.erb
@@ -8,6 +8,10 @@ Requires=docker.service
 
 [Service]
 WorkingDirectory=<%= @kubelet_dir %>
+<% if @cloud_provider == 'aws' -%>
+# prevent metadata service access on AWS
+ExecStartPre=/bin/sh -e -c "iptables -C PREROUTING -p tcp --destination 169.254.169.254 --dport 80 --in-interface <%= @container_interface %> --jump DNAT --table nat --to-destination 127.0.0.1:8181 2> /dev/null || iptables -A PREROUTING -p tcp --destination 169.254.169.254 --dport 80 --in-interface <%= @container_interface %> --jump DNAT --table nat --to-destination 127.0.0.1:8181"
+<% end -%>
 ExecStart=<%= scope['kubernetes::_dest_dir'] %>/kubelet \
   --v=<%= scope['kubernetes::log_level'] %> \
   --register-schedulable=<%= @_register_schedulable %> \
@@ -42,8 +46,8 @@ ExecStart=<%= scope['kubernetes::_dest_dir'] %>/kubelet \
   --network-plugin-mtu=<%= @network_plugin_mtu %> \
 <% end -%>
 <% end -%>
-<% if scope['kubernetes::cloud_provider'] != '' -%>
-  --cloud-provider=<%= scope['kubernetes::cloud_provider'] %> \
+<% if @cloud_provider != '' -%>
+  --cloud-provider=<%= @cloud_provider %> \
 <% end -%>
 <% if @container_runtime -%>
   --container-runtime=<%= @container_runtime %> \


### PR DESCRIPTION
Before it was only disable by enabling the non default kube2iam addon.
This makes sure the iptables rule is set before pods are scheduled to
the node. This also allows to run kube2iam without higher privileges.

https://gitlab.jetstack.net/tarmak/tarmak/issues/168